### PR TITLE
Added Markdown handling

### DIFF
--- a/zsh-ollama-command.zsh
+++ b/zsh-ollama-command.zsh
@@ -85,6 +85,10 @@ fzf_ollama_commands() {
   ZSH_OLLAMA_COMMANDS_SUGGESTION=$(echo "$ZSH_OLLAMA_COMMANDS_SUGGESTION" | tr -d '\0' | jq -r '.message.content')
   check_status
 
+  # Remove markdown code block markers
+  ZSH_OLLAMA_COMMANDS_SUGGESTION="${ZSH_OLLAMA_COMMANDS_SUGGESTION//\`\`\`json/}"
+  ZSH_OLLAMA_COMMANDS_SUGGESTION="${ZSH_OLLAMA_COMMANDS_SUGGESTION//\`\`\`/}"
+
   # attempts to extract suggestions from ZSH_OLLAMA_COMMANDS_SUGGESTION using jq.
   # If jq fails or returns no output, displays an error message and exits.
   # Otherwise, pipes the output to fzf for interactive selection


### PR DESCRIPTION
This small PR adds handling for a scenario if the model response was wrapped in Markdown. Some models (ie. deepseek-coder) tend to ignore the request NOT to wrap the response in Markdown, therefore this change adds handling for such situations, ensuring jq can parse the returned JSON.